### PR TITLE
Auto hide nav buttons and remove nav buttons

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -650,11 +650,6 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
-/* Navigation buttons — auto-hide with hover reveal */
-#nav-bar {
-  container-type: inline-size style;
-}
-
 /* Permanent hide — takes precedence over autohide */
 @container style(--uc-hide-nav-buttons: 1) {
   #back-button,
@@ -665,6 +660,7 @@ browser[type="content"],
   }
 }
 
+/* Navigation buttons — auto-hide with hover reveal */
 /* Mode 1 and 2 apply hidden state */
 @container style(--uc-autohide-nav-buttons: 1), style(--uc-autohide-nav-buttons: 2) {
   #back-button,

--- a/userChrome.css
+++ b/userChrome.css
@@ -108,7 +108,7 @@
   --uc-show-loading-progress: 0;
 
   /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
-  --uc-autohide-nav-buttons: 2;
+  --uc-autohide-nav-buttons: 0;
 
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off

--- a/userChrome.css
+++ b/userChrome.css
@@ -647,6 +647,46 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
+/* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
+#nav-bar {
+  container-type: inline-size style;
+}
+
+/* Only apply when enabled */
+@container style(--uc-autohide-nav-buttons: 1) {
+
+  #back-button,
+  #forward-button,
+  #reload-button,
+  #stop-reload-button {
+    opacity: 0 !important;
+    max-width: 0 !important;
+    min-width: 0 !important;
+    width: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: hidden !important;
+    transition: all 0.2s ease !important;
+  }
+
+  #nav-bar:hover :is(
+    #back-button,
+    #forward-button,
+    #reload-button,
+    #stop-reload-button
+  ),
+  #nav-bar:focus-within :is(
+    #back-button,
+    #forward-button,
+    #reload-button,
+    #stop-reload-button
+  ) {
+    opacity: 1 !important;
+    max-width: 32px !important;
+    width: 32px !important;
+  }
+}
+
 #pageActionButton { display: none !important; }
 #urlbar-go-button { display: none !important; }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -836,7 +836,7 @@ browser[type="content"],
 .tabbrowser-tab[fadein]:not([selected]):not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   max-width: var(--uc-inactive-tab-width) !important;
 }
-.tabbrowser-tab:not([pinned]) {
+.tabbrowser-tab[fadein]:not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   min-width: var(--uc-tab-min-width) !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -42,6 +42,7 @@
   /* Dynamic tab widths */
   --uc-active-tab-width: clamp(100px, 30vw, 250px);
   --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  --uc-tab-min-width: 36px;
 
   /* Inactive tab hover title color (issue #16) */
   --uc-tab-hover-text: #ffda85;
@@ -834,6 +835,9 @@ browser[type="content"],
 }
 .tabbrowser-tab[fadein]:not([selected]):not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   max-width: var(--uc-inactive-tab-width) !important;
+}
+.tabbrowser-tab:not([pinned]) {
+  min-width: var(--uc-tab-min-width) !important;
 }
 
 /* active pinned tab — bottom glow indicator (mirrors container-line style) */

--- a/userChrome.css
+++ b/userChrome.css
@@ -109,7 +109,10 @@
 
   /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
   --uc-autohide-nav-buttons: 0;
-
+	
+  /* Navigation buttons — remove back/forward/reload for mouse button and shortcut users (1 = hide, 0 = show) */
+  --uc-hide-nav-buttons: 0;
+	
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
    * Underline: colored bar below active tab (1 = show, 0 = hide) */
@@ -650,6 +653,16 @@ browser[type="content"],
 /* Navigation buttons — auto-hide with hover reveal */
 #nav-bar {
   container-type: inline-size style;
+}
+
+/* Permanent hide — takes precedence over autohide */
+@container style(--uc-hide-nav-buttons: 1) {
+  #back-button,
+  #forward-button,
+  #reload-button,
+  #stop-reload-button {
+    display: none !important;
+  }
 }
 
 /* Mode 1 and 2 apply hidden state */

--- a/userChrome.css
+++ b/userChrome.css
@@ -107,8 +107,8 @@
   /* Tab loading progress bar (1 = show, 0 = hide) */
   --uc-show-loading-progress: 0;
 
-  /* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
-  --uc-autohide-nav-buttons: 0;
+  /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
+  --uc-autohide-nav-buttons: 2;
 
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
@@ -647,14 +647,13 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
-/* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
+/* Navigation buttons — auto-hide with hover reveal */
 #nav-bar {
   container-type: inline-size style;
 }
 
-/* Only apply when enabled */
-@container style(--uc-autohide-nav-buttons: 1) {
-
+/* Mode 1 and 2 apply hidden state */
+@container style(--uc-autohide-nav-buttons: 1), style(--uc-autohide-nav-buttons: 2) {
   #back-button,
   #forward-button,
   #reload-button,
@@ -668,13 +667,21 @@ browser[type="content"],
     overflow: hidden !important;
     transition: all 0.2s ease !important;
   }
-
+  /* Hover reveal applies to both modes */
   #nav-bar:hover :is(
     #back-button,
     #forward-button,
     #reload-button,
     #stop-reload-button
-  ),
+  ) {
+    opacity: 1 !important;
+    max-width: 32px !important;
+    width: 32px !important;
+  }
+}
+
+/* Mode 1 also reveals on focus */
+@container style(--uc-autohide-nav-buttons: 1) {
   #nav-bar:focus-within :is(
     #back-button,
     #forward-button,


### PR DESCRIPTION
Added functionality to autohide-nav-buttons. 0 = always show, 1 = reveal with hover and focus, 2 = reveal only with hover. One cosmetic issue is the spacing between the left button and window border.

Also added option to hide navigation buttons for people who use shortcuts or mouse side buttons since it's not possible by customizing the toolbar in Firefox.