### PR TITLE
Polish auto-hide nav buttons (fixes on top of #22)

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -650,11 +650,6 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
-/* Navigation buttons — auto-hide with hover reveal */
-#nav-bar {
-  container-type: inline-size style;
-}
-
 /* Permanent hide — takes precedence over autohide */
 @container style(--uc-hide-nav-buttons: 1) {
   #back-button,
@@ -665,6 +660,7 @@ browser[type="content"],
   }
 }
 
+/* Navigation buttons — auto-hide with hover reveal */
 /* Mode 1 and 2 apply hidden state */
 @container style(--uc-autohide-nav-buttons: 1), style(--uc-autohide-nav-buttons: 2) {
   #back-button,

--- a/userChrome.css
+++ b/userChrome.css
@@ -108,7 +108,7 @@
   --uc-show-loading-progress: 0;
 
   /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
-  --uc-autohide-nav-buttons: 2;
+  --uc-autohide-nav-buttons: 0;
 
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off

--- a/userChrome.css
+++ b/userChrome.css
@@ -647,6 +647,46 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
+/* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
+#nav-bar {
+  container-type: inline-size style;
+}
+
+/* Only apply when enabled */
+@container style(--uc-autohide-nav-buttons: 1) {
+
+  #back-button,
+  #forward-button,
+  #reload-button,
+  #stop-reload-button {
+    opacity: 0 !important;
+    max-width: 0 !important;
+    min-width: 0 !important;
+    width: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: hidden !important;
+    transition: all 0.2s ease !important;
+  }
+
+  #nav-bar:hover :is(
+    #back-button,
+    #forward-button,
+    #reload-button,
+    #stop-reload-button
+  ),
+  #nav-bar:focus-within :is(
+    #back-button,
+    #forward-button,
+    #reload-button,
+    #stop-reload-button
+  ) {
+    opacity: 1 !important;
+    max-width: 32px !important;
+    width: 32px !important;
+  }
+}
+
 #pageActionButton { display: none !important; }
 #urlbar-go-button { display: none !important; }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -836,7 +836,7 @@ browser[type="content"],
 .tabbrowser-tab[fadein]:not([selected]):not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   max-width: var(--uc-inactive-tab-width) !important;
 }
-.tabbrowser-tab:not([pinned]) {
+.tabbrowser-tab[fadein]:not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   min-width: var(--uc-tab-min-width) !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -42,6 +42,7 @@
   /* Dynamic tab widths */
   --uc-active-tab-width: clamp(100px, 30vw, 250px);
   --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  --uc-tab-min-width: 36px;
 
   /* Inactive tab hover title color (issue #16) */
   --uc-tab-hover-text: #ffda85;
@@ -834,6 +835,9 @@ browser[type="content"],
 }
 .tabbrowser-tab[fadein]:not([selected]):not([pinned]):not(tab-group[collapsed] .tabbrowser-tab) {
   max-width: var(--uc-inactive-tab-width) !important;
+}
+.tabbrowser-tab:not([pinned]) {
+  min-width: var(--uc-tab-min-width) !important;
 }
 
 /* active pinned tab — bottom glow indicator (mirrors container-line style) */

--- a/userChrome.css
+++ b/userChrome.css
@@ -109,7 +109,10 @@
 
   /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
   --uc-autohide-nav-buttons: 0;
-
+	
+  /* Navigation buttons — remove back/forward/reload for mouse button and shortcut users (1 = hide, 0 = show) */
+  --uc-hide-nav-buttons: 0;
+	
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
    * Underline: colored bar below active tab (1 = show, 0 = hide) */
@@ -650,6 +653,16 @@ browser[type="content"],
 /* Navigation buttons — auto-hide with hover reveal */
 #nav-bar {
   container-type: inline-size style;
+}
+
+/* Permanent hide — takes precedence over autohide */
+@container style(--uc-hide-nav-buttons: 1) {
+  #back-button,
+  #forward-button,
+  #reload-button,
+  #stop-reload-button {
+    display: none !important;
+  }
 }
 
 /* Mode 1 and 2 apply hidden state */

--- a/userChrome.css
+++ b/userChrome.css
@@ -107,8 +107,8 @@
   /* Tab loading progress bar (1 = show, 0 = hide) */
   --uc-show-loading-progress: 0;
 
-  /* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
-  --uc-autohide-nav-buttons: 0;
+  /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
+  --uc-autohide-nav-buttons: 2;
 
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
@@ -647,14 +647,13 @@ browser[type="content"],
    HIDDEN ELEMENTS
    ========================================================================== */
 
-/* Navigation buttons — auto-hide with hover reveal (1 = hide, 0 = always show) */
+/* Navigation buttons — auto-hide with hover reveal */
 #nav-bar {
   container-type: inline-size style;
 }
 
-/* Only apply when enabled */
-@container style(--uc-autohide-nav-buttons: 1) {
-
+/* Mode 1 and 2 apply hidden state */
+@container style(--uc-autohide-nav-buttons: 1), style(--uc-autohide-nav-buttons: 2) {
   #back-button,
   #forward-button,
   #reload-button,
@@ -668,13 +667,21 @@ browser[type="content"],
     overflow: hidden !important;
     transition: all 0.2s ease !important;
   }
-
+  /* Hover reveal applies to both modes */
   #nav-bar:hover :is(
     #back-button,
     #forward-button,
     #reload-button,
     #stop-reload-button
-  ),
+  ) {
+    opacity: 1 !important;
+    max-width: 32px !important;
+    width: 32px !important;
+  }
+}
+
+/* Mode 1 also reveals on focus */
+@container style(--uc-autohide-nav-buttons: 1) {
   #nav-bar:focus-within :is(
     #back-button,
     #forward-button,

--- a/userChrome.css
+++ b/userChrome.css
@@ -109,10 +109,10 @@
 
   /* Navigation buttons — auto-hide with hover reveal (0 = always show, 1 = reveal with hover and focus, 2 = reveal with hover) */
   --uc-autohide-nav-buttons: 0;
-	
+
   /* Navigation buttons — remove back/forward/reload for mouse button and shortcut users (1 = hide, 0 = show) */
   --uc-hide-nav-buttons: 0;
-	
+
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
    * Underline: colored bar below active tab (1 = show, 0 = hide) */
@@ -672,11 +672,10 @@ browser[type="content"],
     min-width: 0 !important;
     width: 0 !important;
     padding: 0 !important;
-    margin: 0 !important;
     overflow: hidden !important;
     transition: all 0.2s ease !important;
   }
-  /* Hover reveal applies to both modes */
+  /* Hover reveal applies to both modes — revert restores native button widths */
   #nav-bar:hover :is(
     #back-button,
     #forward-button,
@@ -684,8 +683,18 @@ browser[type="content"],
     #stop-reload-button
   ) {
     opacity: 1 !important;
-    max-width: 32px !important;
-    width: 32px !important;
+    width: revert !important;
+    min-width: revert !important;
+    max-width: 60px !important;
+    padding-inline: revert !important;
+  }
+  /* Back button has extra native leading padding (8px left vs 2px); revert misses it */
+  #nav-bar:hover #back-button {
+    padding-inline-start: 8px !important;
+  }
+  /* Disabled back/forward stay visible but dimmed, like native */
+  #nav-bar:hover :is(#back-button, #forward-button)[disabled] {
+    opacity: 0.4 !important;
   }
 }
 
@@ -698,8 +707,16 @@ browser[type="content"],
     #stop-reload-button
   ) {
     opacity: 1 !important;
-    max-width: 32px !important;
-    width: 32px !important;
+    width: revert !important;
+    min-width: revert !important;
+    max-width: 60px !important;
+    padding-inline: revert !important;
+  }
+  #nav-bar:focus-within #back-button {
+    padding-inline-start: 8px !important;
+  }
+  #nav-bar:focus-within :is(#back-button, #forward-button)[disabled] {
+    opacity: 0.4 !important;
   }
 }
 


### PR DESCRIPTION
## What

Polishes and fixes the auto-hide / hide navigation buttons feature from #22. Thanks @DeathMurderGod for the original implementation and the three-mode design.

This branch builds directly on #22's commits, so merging it lands that work too. Supersedes #22.

## Fixes on top of #22

- **Reload no longer too narrow** – native button widths are restored via `revert` instead of the hardcoded `32px`, which was smaller than the native button.
- **Back arrow no longer glued to the window edge** – Firefox gives `#back-button` 8px of leading padding (vs 2px on the others). `revert` misses that asymmetric value, so it is restored explicitly.
- **Disabled back/forward dim correctly** – the reveal no longer forces full opacity on disabled buttons, restoring Firefox's native greyed-out cue (previously rendered full white).
- **Smooth slide-in preserved** – `revert` can't animate from 0, so the reveal uses a fixed `max-width` cap as the animatable bound.
- Drops a leftover `margin: 0` from the collapse and normalizes config whitespace.

## Notes

Default stays `0` (feature off). Opt-in via `--uc-autohide-nav-buttons` (1 = hover + focus, 2 = hover only) and `--uc-hide-nav-buttons` (permanent hide). Verified on Firefox ESR 151, all three modes.