### PR TITLE
Nova: one-line theme ready for Firefox 152+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ notes.md
 bugs.md
 ideas.md
 Media/
+docs/backport-triage.md

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FoxOne
 
 **A minimalist one-line Firefox theme.**
-> Ready for Nova. Tested and stable on current Firefox Beta with the upcoming redesign.
+> Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.
@@ -10,15 +10,8 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 
 <br>
 
-</div>
 
-Supported configuration: **Firefox 152+ with `browser.nova.enabled`**. 
-From 3.0 on, that is the only setup tested and maintained.
-
-> Running classic (pre-Nova) Firefox?
-> 
-> The stylesheet is dual-written and should still work, but it is no longer tested there. 
-> For a fully-tested classic build, pin the `2.3` as an earlier base. 
+> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
 
 ---
  

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read](docs/installation.md) | License: [MIT](LICENSE) 
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read me](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Read me](docs/installation.md) | License: [MIT](LICENSE) 
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read me](docs/installation.md) | License: [MIT](LICENSE) 
+Inspired by [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read me](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Based on and inspired by Andreas Grafen's [Cascade](https://github.com/andreasgrafen/cascade) & biglavis' [LittleFox](https://github.com/biglavis/LittleFox) |
-License: [MIT](LICENSE)
-
-**macOS:** under-tested, [maintainer wanted](LINK_TO_ISSUE).
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | **macOS:** under-tested, [maintainer wanted](LINK_TO_ISSUE) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 **A minimalistic one-line Firefox theme.**
 > Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.
-> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.
@@ -11,7 +10,7 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 
 <br>
 
-
+> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FoxOne
 
 **A minimalistic one-line Firefox theme.**
-> Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.
+> **Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.**
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FoxOne
 
-**A minimalist one-line Firefox theme.**
+**A minimalistic one-line Firefox theme.**
 > Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else
 
 Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/FoxOne/blob/main/docs/action.md)
 
-<br>
-
-> **Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)**
-
 
 ---
  

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | **macOS:** under-tested, [maintainer wanted](LINK_TO_ISSUE) | License: [MIT](LICENSE) 
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | **macOS:** under-tested, [maintainer wanted](https://github.com/Firnschnee/FoxOne/issues/18) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FoxOne
 
 **A minimalistic one-line Firefox theme.**
-> **Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.**
+> **Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`**
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.
@@ -10,7 +10,7 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 
 <br>
 
-> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
+> **Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)**
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | **macOS:** under-tested, [maintainer wanted](https://github.com/Firnschnee/FoxOne/issues/18) | License: [MIT](LICENSE) 
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running classic (pre-Nova) Firefox? [Read me](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 
 </div>
 
-Supported configuration: **Firefox 152+ with `browser.nova.enabled`**. From 3.0 on, that is the only setup tested and maintained.
+Supported configuration: **Firefox 152+ with `browser.nova.enabled`**. 
+From 3.0 on, that is the only setup tested and maintained.
 
-Running classic (pre-Nova) Firefox? 
-The stylesheet is dual-written and should still work, but it is no longer tested there. 
-For a fully-tested classic build, pin the `2.3` as an earlier base. 
+> Running classic (pre-Nova) Firefox?
+> 
+> The stylesheet is dual-written and should still work, but it is no longer tested there. 
+> For a fully-tested classic build, pin the `2.3` as an earlier base. 
 
 ---
  

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running classic (pre-Nova) Firefox? [Read me](docs/installation.md) | License: [MIT](LICENSE) 
+Inspired [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Read me](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FoxOne
 
-
 **A minimalist one-line Firefox theme.**
+> **Ready for Nova.** Tested and stable on current Firefox Beta with the upcoming redesign.
 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FoxOne
 
 **A minimalist one-line Firefox theme.**
-> **Ready for Nova.** Tested and stable on current Firefox Beta with the upcoming redesign.
-
+> Ready for Nova. Tested and stable on current Firefox Beta with the upcoming redesign.
+> 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.
 
@@ -10,10 +10,13 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 
 <br>
 
-**And this time: dynamic toolbar support - add an extension icon of your choice right next to the hamburger menu!**
-
 </div>
 
+Supported configuration: **Firefox 152+ with `browser.nova.enabled`**. From 3.0 on, that is the only setup tested and maintained.
+
+Running classic (pre-Nova) Firefox? 
+The stylesheet is dual-written and should still work, but it is no longer tested there. 
+For a fully-tested classic build, pin the `2.3` as an earlier base. 
 
 ---
  

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 ---
  
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
-Inspired by [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read me](docs/installation.md) | License: [MIT](LICENSE) 
+Inspired by [Cascade](https://github.com/andreasgrafen/cascade) & [LittleFox](https://github.com/biglavis/LittleFox) | Running pre-Nova Firefox? [Please read](docs/installation.md) | License: [MIT](LICENSE) 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 **[Installation](docs/installation.md) & [Customisation](https://github.com/Firnschnee/FoxOne/blob/main/docs/customisation.md)** |
 Based on and inspired by Andreas Grafen's [Cascade](https://github.com/andreasgrafen/cascade) & biglavis' [LittleFox](https://github.com/biglavis/LittleFox) |
 License: [MIT](LICENSE)
+
+**macOS:** under-tested, [maintainer wanted](LINK_TO_ISSUE).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **A minimalistic one-line Firefox theme.**
 > Ready for Nova. Tested and stable on Firefox 152+ with `browser.nova.enabled`.
+> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
 > 
 <img width="1920" height="1080" alt="640_1x_shots_so" src="https://github.com/user-attachments/assets/f2d49a1e-f56c-4cf6-b1d2-40a36d1eb084" /><br>
 One-line layout. Clean URL bar. Hover-reveal icons. Gruvbox colors. Nothing else.
@@ -11,7 +12,7 @@ Want to see it in action? [Watch the animations!](https://github.com/Firnschnee/
 <br>
 
 
-> Running classic (pre-Nova) Firefox? [Read here](docs/installation.md)
+
 
 ---
  

--- a/docs/action.md
+++ b/docs/action.md
@@ -1,11 +1,11 @@
 **One-line layout. Hover-reveal icons and dynamic Tabs**
 
-<img width="1200" height="81" alt="ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/b6a233a3-6412-4c1b-96eb-646a21cae443" />
+<img width="800" height="100" alt="hover" src="https://github.com/user-attachments/assets/2fa3a838-c9f2-4118-ab46-19f3b180ec54" />
 
 **Dynamic Urlbar**
 
-<img width="1200" height="149" alt="dynamicbar-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/d6467671-3e5a-4e30-8071-dcf98ab80dd9" />
+<img width="800" height="95" alt="urlbar" src="https://github.com/user-attachments/assets/7d0ee002-6244-4815-a551-64f151b64398" />
 
 **Findbar**
 
-<img width="1200" height="160" alt="ezgif com-video-to-gif-converter(1)" src="https://github.com/user-attachments/assets/4c23c8b2-0e68-4606-916a-a31db4244885" />
+<img width="800" height="96" alt="findbar" src="https://github.com/user-attachments/assets/9032e927-0885-41fd-b202-b2795e4dfcb4" />

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -2,7 +2,7 @@
 ---
 > Running classic (pre-Nova) Firefox?
 >
-> From release 3.0 onward, FoxOne targets the Nova UI. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
+> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written (Proton & Nova) and should still work, but it is no longer tested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
 ---
 All configuration lives in the `:root` block at the top of `userChrome.css`.
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -73,6 +73,7 @@ Both options can be combined for maximum visibility.
 | `--uc-autohide-nav-buttons` | `0` | Navigation buttons auto-hide (`0` = always visible, `1` = reveal on hover and focus, `2` = reveal on hover only) |
 | `--uc-hide-nav-buttons` | `0` | Remove navigation buttons entirely (`1` = hide, `0` = show) |
 | `--uc-hide-urlbar-buttons` | `0` | Hide URL-bar clutter icons — shield (tracking protection), reader mode, translations, bookmark star, add-to-taskbar (`1` = hide all, `0` = default reveal) |
+| `--uc-hide-extension-icons` | `0` | Hide pinned toolbar extension icons, reveal them on hamburger hover (`1` = hide + hover-reveal, `0` = always show) |
 
 ### Scrollbar (`userContent.css`)
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -72,6 +72,7 @@ Both options can be combined for maximum visibility.
 | `--uc-show-all-tabs-button` | `none` | All-tabs button (`none` = hidden, `-moz-box` = visible) |
 | `--uc-autohide-nav-buttons` | `0` | Navigation buttons auto-hide (`0` = always visible, `1` = reveal on hover and focus, `2` = reveal on hover only) |
 | `--uc-hide-nav-buttons` | `0` | Remove navigation buttons entirely (`1` = hide, `0` = show) |
+| `--uc-hide-urlbar-buttons` | `0` | Hide URL-bar clutter icons — shield (tracking protection), reader mode, translations, bookmark star, add-to-taskbar (`1` = hide all, `0` = default reveal) |
 
 ### Scrollbar (`userContent.css`)
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -1,5 +1,10 @@
 # Customisation
-
+---
+> Running classic (pre-Nova) Firefox?
+> 
+> The stylesheet is dual-written and should still work, but it is no longer tested there. 
+> For a fully-tested classic build, pin the `2.3` as an earlier base. 
+---
 All configuration lives in the `:root` block at the top of `userChrome.css`.
 
 ### Color Palette

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -30,8 +30,8 @@ All configuration lives in the `:root` block at the top of `userChrome.css`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `--uc-active-tab-width` | `clamp(100px, 30vw, 190px)` | Active tab width |
-| `--uc-inactive-tab-width` | `clamp(100px, 20vw, 120px)` | Inactive tab width (ceiling kept below the active one so the active tab stays visibly larger) |
+| `--uc-active-tab-width` | `clamp(100px, 30vw, 190px)` | Active tab width (narrow-window default; widened to `…250px` once the window reaches ~1710 *physical* px, i.e. ~2/3 of WQHD — the threshold is tiered by `resolution`/dppx so it fires at the same physical size under DPI scaling) |
+| `--uc-inactive-tab-width` | `clamp(100px, 20vw, 120px)` | Inactive tab width (ceiling kept below the active one so the active tab stays visibly larger; widened to `…200px` at the same ~1710 physical-px threshold) |
 | `--uc-tab-min-width` | `76px` | Tab minimum width (Firefox default: `76px`, lower e.g. `36px` to fit more before overflow) |
 | `--uc-tab-hover-text` | `#ffda85` | Inactive tab title color on hover |
 | `--show-tab-close-button` | `none` | Tab close button (`none` = hidden, `-moz-inline-block` = visible) |

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -31,7 +31,7 @@ All configuration lives in the `:root` block at the top of `userChrome.css`.
 | Variable | Default | Description |
 |---|---|---|
 | `--uc-active-tab-width` | `clamp(100px, 30vw, 250px)` | Active tab width |
-| `--uc-inactive-tab-width` | `clamp(100px, 20vw, 200px)` | Inactive tab width |
+| `--uc-inactive-tab-width` | `clamp(100px, 20vw, 120px)` | Inactive tab width (ceiling kept below the active one so the active tab stays visibly larger) |
 | `--uc-tab-min-width` | `76px` | Tab minimum width (Firefox default: `76px`, lower e.g. `36px` to fit more before overflow) |
 | `--uc-tab-hover-text` | `#ffda85` | Inactive tab title color on hover |
 | `--show-tab-close-button` | `none` | Tab close button (`none` = hidden, `-moz-inline-block` = visible) |

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -2,13 +2,23 @@
 
 All configuration lives in the `:root` block at the top of `userChrome.css`.
 
+### Color Palette
+
+| Variable | Default | Description |
+|---|---|---|
+| `--uc-color-base` | `#282828` | Main background (toolbar, frame) |
+| `--uc-color-surface` | `#3c3836` | Elevated surfaces (panels, popups) |
+| `--uc-color-accent` | `#fabd2f` | Accent color (active tab, focus ring) |
+| `--uc-color-text` | `#FFFFFF` | Primary text |
+| `--uc-color-hover` | `#7c6f64` | Hover / highlight backgrounds |
+
 ### Layout
 
 | Variable | Default | Description |
 |---|---|---|
 | `--uc-border-radius` | `8px` | Global corner radius |
 | `--uc-status-panel-spacing` | `12px` | Statuspanel distance from window border (`0` = corner) |
-| `--uc-urlbar-background` | `#282828` | URL bar background (`#282828` = blends with toolbar, `#3c3836` = distinct) |
+| `--uc-urlbar-background` | `var(--uc-color-base)` | URL bar background (`var(--uc-color-base)` = blends with toolbar, `var(--uc-color-surface)` = distinct) |
 | `--uc-urlbar-rounded` | `0` | Rounded corners on URL bar and findbar (`1` = rounded, `0` = square) |
 | `--uc-urlbar-min-width` | `35vw` | URL bar default width |
 | `--uc-urlbar-max-width` | `50vw` | URL bar width on focus |
@@ -22,9 +32,11 @@ All configuration lives in the `:root` block at the top of `userChrome.css`.
 |---|---|---|
 | `--uc-active-tab-width` | `clamp(100px, 30vw, 250px)` | Active tab width |
 | `--uc-inactive-tab-width` | `clamp(100px, 20vw, 200px)` | Inactive tab width |
+| `--uc-tab-min-width` | `76px` | Tab minimum width (Firefox default: `76px`, lower e.g. `36px` to fit more before overflow) |
+| `--uc-tab-hover-text` | `#ffda85` | Inactive tab title color on hover |
 | `--show-tab-close-button` | `none` | Tab close button (`none` = hidden, `-moz-inline-block` = visible) |
 | `--show-tab-close-button-hover` | `-moz-inline-block` | Tab close button on hover |
-| `--uc-show-loading-progress` | `1` | Tab loading progress bar (`1` = show, `0` = hide) |
+| `--uc-show-loading-progress` | `0` | Tab loading progress bar (`1` = show, `0` = hide) |
 
 ### Active Tab Highlight
 
@@ -47,7 +59,6 @@ Both options can be combined for maximum visibility.
 | Variable | Default | Description |
 |---|---|---|
 | `--uc-window-buttons-width` | `138px` | Windows control button width (auto `0px` on macOS) |
-| `--uc-traffic-light-width` | `80px` | macOS only — space reserved for traffic light buttons |
 | `--uc-hamburger-width` | `44px` | Hamburger menu reserved width |
 | `--uc-toolbar-button-width` | `36px` | Extension button width (per button) |
 | `--uc-newtab-width` | `36px` | Standalone new-tab button width (`0` if removed) |
@@ -59,7 +70,8 @@ Both options can be combined for maximum visibility.
 |---|---|---|
 | `--uc-show-context-splitview` | `none` | Context menu "Open Link in Split View" (`none` = hidden, `-moz-box` = visible) |
 | `--uc-show-all-tabs-button` | `none` | All-tabs button (`none` = hidden, `-moz-box` = visible) |
-| `--uc-autohide-nav-buttons` | `0` | Navigation buttons auto-hide (`1` = hidden until hover, `0` = always visible) |
+| `--uc-autohide-nav-buttons` | `0` | Navigation buttons auto-hide (`0` = always visible, `1` = reveal on hover and focus, `2` = reveal on hover only) |
+| `--uc-hide-nav-buttons` | `0` | Remove navigation buttons entirely (`1` = hide, `0` = show) |
 
 ### Scrollbar (`userContent.css`)
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -58,7 +58,7 @@ Both options can be combined for maximum visibility.
 
 | Variable | Default | Description |
 |---|---|---|
-| `--uc-window-buttons-width` | `138px` | Windows control button width (auto `0px` on macOS) |
+| `--uc-window-buttons-width` | `138px` | Window control button width. Fallback only: on non-macOS the hamburger auto-tracks the real control box via CSS anchor positioning; used on macOS and on Firefox builds without anchor support (auto `0px` on macOS) |
 | `--uc-hamburger-width` | `44px` | Hamburger menu reserved width |
 | `--uc-toolbar-button-width` | `36px` | Extension button width (per button) |
 | `--uc-newtab-width` | `36px` | Standalone new-tab button width (`0` if removed) |

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -1,9 +1,8 @@
 # Customisation
 ---
 > Running classic (pre-Nova) Firefox?
-> 
-> The stylesheet is dual-written and should still work, but it is no longer tested there. 
-> For a fully-tested classic build, pin the `2.3` as an earlier base. 
+>
+> From release 3.0 onward, FoxOne targets the Nova UI. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
 ---
 All configuration lives in the `:root` block at the top of `userChrome.css`.
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -30,7 +30,7 @@ All configuration lives in the `:root` block at the top of `userChrome.css`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `--uc-active-tab-width` | `clamp(100px, 30vw, 250px)` | Active tab width |
+| `--uc-active-tab-width` | `clamp(100px, 30vw, 190px)` | Active tab width |
 | `--uc-inactive-tab-width` | `clamp(100px, 20vw, 120px)` | Inactive tab width (ceiling kept below the active one so the active tab stays visibly larger) |
 | `--uc-tab-min-width` | `76px` | Tab minimum width (Firefox default: `76px`, lower e.g. `36px` to fit more before overflow) |
 | `--uc-tab-hover-text` | `#ffda85` | Inactive tab title color on hover |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ---
 > Running classic (pre-Nova) Firefox?
 >
-> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written and should still work, but it is no longer tested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
+> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written (Proton & Nova) and should still work, but it is no longer tested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
 ---
 
 ### 1. Download

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,11 @@
 # Installation
 
+---
+> Running classic (pre-Nova) Firefox?
+>
+> From release 3.0 onward, FoxOne targets the Nova UI. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
+---
+
 ### 1. Download
 
 Download [`userChrome.css`](https://github.com/Firnschnee/FoxOne/blob/main/userChrome.css) and [`userContent.css`](https://github.com/Firnschnee/FoxOne/blob/main/userContent.css)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ---
 > Running classic (pre-Nova) Firefox?
 >
-> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written and should still work, but it is no longer tested there. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
+> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written and should still work, but it is no longer tested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
 ---
 
 ### 1. Download

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ---
 > Running classic (pre-Nova) Firefox?
 >
-> From release 3.0 onward, FoxOne targets the Nova UI. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
+> From release 3.0 onward, FoxOne targets the Nova UI. The stylesheet is dual-written and should still work, but it is no longer tested there. Parts may still work on classic Firefox, but this is untested. For a known-good classic build, use the [2.3](https://github.com/Firnschnee/FoxOne/releases/tag/2.3) release.
 ---
 
 ### 1. Download

--- a/docs/nova-regression.md
+++ b/docs/nova-regression.md
@@ -1,0 +1,70 @@
+# Nova Regression Checklist
+
+FoxOne's `nova` branch tracks Firefox's Nova redesign, which is still in beta.
+Nova ships rename churn: CSS custom-property tokens, element ids, and class
+names change between beta uplifts with no notice. The robust parts of FoxOne
+(the `@container` opt-in toggles, anchor positioning) do not break on a rename;
+the fragile parts are the **id / class / token dependencies** listed below.
+
+Run this checklist after every Nova beta update. It is not a full audit of the
+theme: it is the short list of things Nova has already moved once and is likely
+to move again. If a symptom below appears, the named dependency probably got
+renamed: inspect the element in the Browser Toolbox, read the new
+token/id/class, and update the matching rule (keeping the old name too, so the
+theme still works on the previous channel).
+
+## How to check
+
+1. Open a fresh Nova profile with the current `userChrome.css`.
+2. For each item, look for the **symptom**. No symptom = still fine.
+3. If a symptom shows, open the Browser Toolbox (`Ctrl+Alt+Shift+I`), inspect
+   the named element, and compare the **Computed** / **Rules** panel against the
+   dependency FoxOne expects. The rename is usually visible as a struck-through
+   or unmatched property.
+
+## Colour tokens
+
+| Check | Symptom if broken | FoxOne dependency |
+|---|---|---|
+| Toolbar / toolbox background | Bookmarks bar and sidebar drift to `#2b2a33` instead of base | `--toolbar-background-color`, `--toolbox-background-color` (Nova renamed from `--toolbar-bgcolor`); both pinned in the COLOR THEME block |
+| Inactive tab hover | Grey hover background returns behind the title (issue #16) | `--tab-background-color-hover` (Nova flipped the word order from `--tab-hover-background-color`, `tab.tokens.css`); both names overridden |
+| Bookmarks bar background | Bookmarks bar shows the default dark toolbar colour, not base | Nova sets the bookmarks-bar background directly instead of inheriting `--toolbar-bgcolor` |
+
+## Tabs
+
+| Check | Symptom if broken | FoxOne dependency |
+|---|---|---|
+| Active tab framing | A gradient "border" reappears around the active tab | Nova paints it via a layered `background-image` (`--tab-border-color-accent`); FoxOne overrides the active-tab background |
+
+## URL bar
+
+| Check | Symptom if broken | FoxOne dependency |
+|---|---|---|
+| URL field blending | The field stops blending into the toolbar, or shows a 1px deemphasized border | Nova rebuilt the urlbar as `<moz-urlbar>` and moved internals from id to class (`.urlbar-background`, `.urlbar-input-container`, `urlbar-searchbar.css`); both legacy id and Nova classes are reset |
+| Results dropdown | The open results panel blends into the page with no separation | Nova ships the panel without border/shadow; FoxOne restores a 1px outline |
+| Shield / security icon padding | The shield/trust icon padding looks off | `#urlbar-input-container` moved from id to class; FoxOne matches both `#urlbar-input-container` and `.urlbar-input-container` |
+| Trust icon alignment | `#trust-icon` sits ~2px too high relative to the other urlbar icons | Nova added `#trust-icon` inside `#trust-icon-container` next to a flex `#trust-label`; nudged down 2px |
+| Search-mode switcher | A violet frame appears on the engine-icon switcher | Nova's switcher is a `moz-button` whose visible button lives in the shadow DOM (`part="button"`) |
+| Hide-urlbar-buttons toggle | With `--uc-hide-urlbar-buttons: 1`, the shield no longer hides | Shield is `#trust-icon-container` on Nova (pre-Nova: `#tracking-protection-icon-container`); both targeted |
+
+## Chrome-block framing and layout
+
+| Check | Symptom if broken | FoxOne dependency |
+|---|---|---|
+| Edge-to-edge chrome | Toolbox / sidebar / panels float inset with a margin and rounded corners | Nova frames every `.chrome-block` container with a 4px margin + 8px radius (`--chrome-block-radius`); `#navigator-toolbox`, `#sidebar-main` etc. carry `class="chrome-block"`; FoxOne flattens `.chrome-block` |
+| Web content edge | The page is pushed off the window edge, or a 4px gap appears | Nova insets web content on `#browser` (flex hbox) via padding + a 4px flex gap |
+| Content separator | Web content is pushed 1px down | Nova draws the 1px chrome-content separator on `.browserContainer` |
+
+## Window controls / hamburger
+
+| Check | Symptom if broken | FoxOne dependency |
+|---|---|---|
+| Hamburger position (non-macOS) | Hamburger overlaps or gaps from the window-control buttons | `anchor-name: --uc-winbtns` on `.titlebar-buttonbox-container`, `right: anchor(...)` on `#PanelUI-button`; falls back to `--uc-window-buttons-width` if anchor positioning regresses (issue #9) |
+| macOS traffic lights | Traffic lights misaligned, or content lacks left inset | `.titlebar-buttonbox-container` positioned absolute left; `#nav-bar` left padding (`--uc-traffic-light-width`); both under `@media (-moz-platform: macos)` |
+
+## When a rename is found
+
+1. Inspect, read the new name, update the rule, keep the old name as well.
+2. If a whole feature breaks (not just a token), treat it as a real bug and use
+   the systematic-debugging approach: confirm the root cause before patching.
+3. Note the rename in the relevant inline comment so the next uplift is faster.

--- a/userChrome.css
+++ b/userChrome.css
@@ -122,6 +122,10 @@
    * misclicked when aiming for the URL bar (1 = hide all, 0 = default reveal) */
   --uc-hide-urlbar-buttons: 0;
 
+  /* Pinned toolbar extension icons — hide and reveal on hamburger hover, to
+   * keep the one-line layout clean (1 = hide + hover-reveal, 0 = always show) */
+  --uc-hide-extension-icons: 1;
+
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
    * Underline: colored bar below active tab (1 = show, 0 = hide) */
@@ -985,6 +989,41 @@ browser[type="content"],
 /* Only the last item clears the fixed hamburger; intermediate items stay snug. */
 #TabsToolbar-customization-target > toolbaritem:last-of-type {
   margin-inline-end: var(--uc-hamburger-width) !important;
+}
+
+/* Opt-in: hide the pinned extension icons and reveal them on hamburger hover.
+   The hamburger is position:fixed in a separate toolbar, so there is no plain
+   combinator to the icons; the reveal is driven via :root:has(). The second
+   reveal selector (cluster :hover) is the bridge that keeps the icons open
+   while the pointer travels from the hamburger onto them. (Issue #13) */
+@container style(--uc-hide-extension-icons: 1) {
+  #TabsToolbar-customization-target > toolbaritem {
+    max-width: 0 !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+    padding-inline: 0 !important;
+    overflow: hidden !important;
+    transition: max-width 0.2s ease, opacity 0.2s ease,
+                padding-inline 0.2s ease, margin-inline 0.2s ease !important;
+  }
+  /* collapsed last item drops the hamburger clearance so no gap is reserved */
+  #TabsToolbar-customization-target > toolbaritem:last-of-type {
+    margin-inline-end: 0 !important;
+  }
+
+  /* Reveal: hovering the hamburger, or the cluster itself (the bridge). */
+  :root:has(#PanelUI-button:hover) #TabsToolbar-customization-target > toolbaritem,
+  :root:has(#TabsToolbar-customization-target:hover) #TabsToolbar-customization-target > toolbaritem {
+    max-width: 60px !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    padding-inline: revert !important;
+  }
+  /* restore the hamburger clearance on the revealed cluster's last item */
+  :root:has(#PanelUI-button:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type,
+  :root:has(#TabsToolbar-customization-target:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type {
+    margin-inline-end: var(--uc-hamburger-width) !important;
+  }
 }
 
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -113,6 +113,11 @@
   /* Navigation buttons — remove back/forward/reload for mouse button and shortcut users (1 = hide, 0 = show) */
   --uc-hide-nav-buttons: 0;
 
+  /* URL-bar clutter icons — fully hide shield (tracking protection), reader
+   * mode, translations, bookmark star and add-to-taskbar so they can't be
+   * misclicked when aiming for the URL bar (1 = hide all, 0 = default reveal) */
+  --uc-hide-urlbar-buttons: 0;
+
   /* Active tab highlight (combine or use individually)
    * Background: set a hex color to enable (e.g. #3c3836), transparent = off
    * Underline: colored bar below active tab (1 = show, 0 = hide) */
@@ -911,6 +916,23 @@ browser[type="content"],
   pointer-events: auto !important;
   padding: 6px !important;
   margin: 0 !important;
+}
+
+/* Opt-in: fully hide URL-bar clutter icons, no hover/focus reveal.
+   display:none removes them regardless of the reveal rules above, so misclicks
+   while aiming for the URL bar are impossible. The shield/security indicator
+   (Nova: #trust-icon-container; pre-Nova: #tracking-protection-icon-container)
+   and #star-button-box are otherwise always visible; this is the only thing
+   that hides them. (Issue #21) */
+@container style(--uc-hide-urlbar-buttons: 1) {
+  #trust-icon-container,
+  #tracking-protection-icon-container,
+  #reader-mode-button,
+  #taskbar-tabs-button,
+  #translations-button,
+  #star-button-box {
+    display: none !important;
+  }
 }
 
 /* Hide private browsing indicator */

--- a/userChrome.css
+++ b/userChrome.css
@@ -1093,10 +1093,16 @@ browser[type="content"],
     pointer-events: auto !important;
     padding-inline: revert !important;
   }
-  /* restore the hamburger clearance on the revealed cluster's last item */
+  /* Hamburger clearance on the revealed cluster's last item as PADDING, not
+     margin, so the 44px lives inside the item's own hover box. That closes the
+     dead zone between the last icon and the fixed hamburger: the toolbaritem
+     :hover bridge now spans the whole gap, so the icons stay open while the
+     pointer travels from the hamburger onto them. max-width grows by the same
+     amount so the icon is not squeezed by the padding (border-box). (#13) */
   :root:has(#PanelUI-button:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type,
   :root:has(#TabsToolbar-customization-target > toolbaritem:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type {
-    margin-inline-end: var(--uc-hamburger-width) !important;
+    max-width: calc(60px + var(--uc-hamburger-width)) !important;
+    padding-inline-end: var(--uc-hamburger-width) !important;
   }
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -1015,8 +1015,10 @@ browser[type="content"],
 /* Opt-in: hide the pinned extension icons and reveal them on hamburger hover.
    The hamburger is position:fixed in a separate toolbar, so there is no plain
    combinator to the icons; the reveal is driven via :root:has(). The second
-   reveal selector (cluster :hover) is the bridge that keeps the icons open
-   while the pointer travels from the hamburger onto them. (Issue #13) */
+   reveal selector (an extension item's own :hover) is the bridge that keeps
+   the icons open while the pointer travels from the hamburger onto them. It
+   must target the toolbaritems specifically, not the customization-target,
+   which spans the whole tab strip and would reveal on any tab hover. (#13) */
 @container style(--uc-hide-extension-icons: 1) {
   #TabsToolbar-customization-target > toolbaritem {
     max-width: 0 !important;
@@ -1032,9 +1034,9 @@ browser[type="content"],
     margin-inline-end: 0 !important;
   }
 
-  /* Reveal: hovering the hamburger, or the cluster itself (the bridge). */
+  /* Reveal: hovering the hamburger, or an extension item itself (the bridge). */
   :root:has(#PanelUI-button:hover) #TabsToolbar-customization-target > toolbaritem,
-  :root:has(#TabsToolbar-customization-target:hover) #TabsToolbar-customization-target > toolbaritem {
+  :root:has(#TabsToolbar-customization-target > toolbaritem:hover) #TabsToolbar-customization-target > toolbaritem {
     max-width: 60px !important;
     opacity: 1 !important;
     pointer-events: auto !important;
@@ -1042,7 +1044,7 @@ browser[type="content"],
   }
   /* restore the hamburger clearance on the revealed cluster's last item */
   :root:has(#PanelUI-button:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type,
-  :root:has(#TabsToolbar-customization-target:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type {
+  :root:has(#TabsToolbar-customization-target > toolbaritem:hover) #TabsToolbar-customization-target > toolbaritem:last-of-type {
     margin-inline-end: var(--uc-hamburger-width) !important;
   }
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -481,6 +481,11 @@ sidebar-main,
 #urlbar[open] > #urlbar-background,
 #urlbar[open] > .urlbar-background {
   background: var(--toolbar-field-background-color) !important;
+  /* Nova ships the open results panel without the border/shadow that used
+     to separate it, so it blends into the page. Restore a 1px outline.
+     Higher specificity (id+class) than the global border:none reset, so it
+     only applies while the dropdown is open; the closed field stays flush. */
+  border: 1px solid var(--uc-color-surface) !important;
 }
 
 .urlbarView-row:hover > .urlbarView-row-inner {

--- a/userChrome.css
+++ b/userChrome.css
@@ -1302,7 +1302,7 @@ tab-split-view-wrapper {
   &[splitview] {
     & .browserContainer {
       .deck-selected > & {
-        outline: 2px solid #fabd2f !important;
+        outline: 1px solid #fabd2f !important;
       }
     }
   }

--- a/userChrome.css
+++ b/userChrome.css
@@ -242,6 +242,14 @@ sidebar-main,
   padding-bottom: 1px;
 }
 
+/* Nova added #trust-icon (site-info/security icon) inside the new
+   #trust-icon-container, sitting next to a flex #trust-label. The icon box
+   is a symmetric 16x16 (no margin/padding), yet Nova renders it ~2px too
+   high relative to the other urlbar icons. Nudge it down to align. */
+#trust-icon {
+  margin-top: 2px !important;
+}
+
 #TabsToolbar { order: 2; }
 #nav-bar { order: 3; }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -133,8 +133,11 @@
     --uc-highlight-colour: var(--uc-color-base);
     --lwt-tab-line-color: var(--uc-color-accent) !important;
     --tab-selected-textcolor: var(--uc-color-accent) !important;
-    /* Kill native grey hover background – hover is a title-colour cue (issue #16) */
+    /* Kill native grey hover background – hover is a title-colour cue (issue #16).
+       Nova renamed the token to --tab-background-color-hover (word order
+       flipped, tab.tokens.css); override both names. */
     --tab-hover-background-color: transparent !important;
+    --tab-background-color-hover: transparent !important;
 
     /* Icons */
     --lwt-toolbarbutton-icon-fill-attention: var(--uc-color-accent) !important;
@@ -954,6 +957,10 @@ browser[type="content"],
 /* selected tab background + configurable highlight */
 .tabbrowser-tab[selected] .tab-background {
   background-color: var(--uc-active-tab-background) !important;
+  /* Nova paints a gradient "border" on the active tab via a layered
+     background-image (--tab-border-color-accent). FoxOne marks the active
+     tab with accent text + optional underline, so kill the gradient. */
+  background-image: none !important;
   box-shadow: inset 0 calc(var(--uc-active-tab-underline) * -2px) 0 0
     var(--tab-selected-textcolor, #fabd2f) !important;
   outline: none !important;

--- a/userChrome.css
+++ b/userChrome.css
@@ -78,8 +78,9 @@
   /* Standalone new-tab button width (set to 0 if removed from toolbar) */
   --uc-newtab-width: 36px;
 
-  /* Drag space — gap between tabs and toolbar buttons for window dragging */
-  --uc-drag-space: 40px;
+  /* Drag space — grab zone after the tabs for moving the window. Kept small;
+     it is functional space, not just a gap, so don't drop it to 0. */
+  --uc-drag-space: 20px;
 
   /* Findbar — floating search bar */
   --findbar-top: 8px;
@@ -973,7 +974,16 @@ browser[type="content"],
    ========================================================================== */
 
 #TabsToolbar-customization-target > toolbaritem {
+  margin-inline: 0 !important;
+}
+/* Only the first item gets the auto start-margin, so the whole group shifts
+   right as one cluster instead of each item claiming its own slice of free
+   space (which split a second icon off toward the middle). */
+#TabsToolbar-customization-target > toolbaritem:first-of-type {
   margin-inline-start: auto !important;
+}
+/* Only the last item clears the fixed hamburger; intermediate items stay snug. */
+#TabsToolbar-customization-target > toolbaritem:last-of-type {
   margin-inline-end: var(--uc-hamburger-width) !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -258,6 +258,10 @@ sidebar-main,
   box-shadow: inset 0 0 50vh rgba(0, 0, 0, var(--uc-darken-toolbar)) !important;
   order: var(--uc-toolbar-position);
   width: 100%;
+  /* Nova sets the bookmarks bar background directly (#2b2a33, the default
+     dark toolbar colour) instead of inheriting --toolbar-bgcolor, so it
+     drifts from the navbar. Pin it to the palette base. */
+  background-color: var(--uc-color-base) !important;
 }
 
 #statuspanel #statuspanel-label {

--- a/userChrome.css
+++ b/userChrome.css
@@ -407,6 +407,17 @@ sidebar-main,
      it. Side effect: removing the 4px top margin realigns #PanelUI-button
      (position: fixed; top: 0), which the margin had pushed out of sync. */
   margin: 0 !important;
+  /* Nova rounds the toolbox via the chrome-block class
+     (--chrome-block-radius: 8px), rounding the toolbar top and the
+     bookmarks-bar bottom. Square it. */
+  border-radius: 0 !important;
+}
+
+/* Nova insets the web content with padding on #browser (the hbox wrapping
+   sidebar + content), leaving the page floating inside a frame. Remove it
+   so content sits flush with the window edge. */
+#browser {
+  padding: 0 !important;
 }
 
 #browser,

--- a/userChrome.css
+++ b/userChrome.css
@@ -661,10 +661,14 @@ sidebar-main,
   --sidebar-border-color: transparent !important;
 }
 
-/* splitter between content and sidebar — thin 2px line, still draggable */
+/* splitter between content and sidebar — thin 2px line, still draggable.
+   Use --toolbar-bgcolor (not the hardcoded dark base) so it blends in both
+   colour schemes: dark mode resolves it to base via FoxOne's override, light
+   mode to the system toolbar tone. Without this the dark splitter shows as a
+   black bar next to light content. */
 #sidebar-splitter {
   border: none !important;
-  background: var(--uc-color-base) !important;
+  background: var(--toolbar-bgcolor) !important;
   appearance: none !important;
   width: 2px !important;
   min-width: 2px !important;
@@ -1229,7 +1233,9 @@ tab-split-view-wrapper {
 
 .split-view-splitter {
   border: none !important;
-  background: var(--uc-color-base) !important;
+  /* same adaptive splitter colour as #sidebar-splitter — blends in light
+     and dark instead of a hardcoded dark base */
+  background: var(--toolbar-bgcolor) !important;
   appearance: none !important;
   width: 2px !important;
   min-width: 2px !important;

--- a/userChrome.css
+++ b/userChrome.css
@@ -128,6 +128,12 @@
     --toolbar-bgcolor: var(--uc-color-base) !important;
     --toolbar-color: var(--uc-color-text) !important;
     --lwt-text-color: var(--uc-color-text) !important;
+    /* Nova renamed the toolbar/toolbox colour tokens (--toolbar-bgcolor →
+       --toolbar-background-color, plus --toolbox-background-color for
+       chrome-blocks). FoxOne's old override misses them, so the bookmarks
+       bar and sidebar drifted to #2b2a33. Pin both to base. */
+    --toolbar-background-color: var(--uc-color-base) !important;
+    --toolbox-background-color: var(--uc-color-base) !important;
 
     /* Tabs */
     --uc-highlight-colour: var(--uc-color-base);
@@ -414,27 +420,37 @@ sidebar-main,
 
 #navigator-toolbox {
   border-bottom: 0 solid transparent !important;
-  /* Nova frames the toolbox with a 4px margin, letting the window
-     background show through as a border. FoxOne is edge-to-edge, so drop
-     it. Side effect: removing the 4px top margin realigns #PanelUI-button
-     (position: fixed; top: 0), which the margin had pushed out of sync. */
+}
+
+/* Nova frames every .chrome-block container (toolbox, sidebar, content) with
+   a 4px margin and an 8px radius (--chrome-block-radius), letting the window
+   background show through as a border and leaving panels floating inset.
+   #navigator-toolbox, #sidebar-main and others all carry class="chrome-block".
+   FoxOne is edge-to-edge, so flatten them all at the source. Side effects:
+   removes the toolbox 4px top margin (realigns #PanelUI-button, fixed top:0),
+   the sidebar side gaps, and the AI-panel height/strip mismatch. */
+.chrome-block {
   margin: 0 !important;
-  /* Nova rounds the toolbox via the chrome-block class
-     (--chrome-block-radius: 8px), rounding the toolbar top and the
-     bookmarks-bar bottom. Square it. */
   border-radius: 0 !important;
 }
 
-/* Nova insets the web content with padding on #browser (the hbox wrapping
-   sidebar + content), leaving the page floating inside a frame. Remove it
-   so content sits flush with the window edge. */
+/* Nova insets the web content on #browser (the flex hbox wrapping sidebar +
+   content): padding pushed the page off the window edge, and a 4px flex gap
+   (column + row) left strips between content and sidebar and a height/strip
+   mismatch on the AI panel. Remove both — the 2px #sidebar-splitter still
+   divides content from sidebar. */
 #browser {
   padding: 0 !important;
+  gap: 0 !important;
 }
 
 #browser,
 #appcontent,
-#tabbrowser-tabbox {
+#tabbrowser-tabbox,
+/* Nova draws the 1px chrome-content separator on .browserContainer too,
+   which the old list missed — it pushed the web content 1px below the AI
+   sidebar. */
+.browserContainer {
   border-top: none !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -42,7 +42,12 @@
   /* Dynamic tab widths. The inactive ceiling is intentionally lower than the
      active one: inactive tabs cap sooner, freeing strip space for the active
      tab to grow visibly larger. Raise it back toward the active ceiling and the
-     active-tab size advantage only appears at very wide strips (issue #7). */
+     active-tab size advantage only appears at very wide strips (issue #7).
+
+     These are the narrow-window defaults (< 1710px). At and above 1710px
+     (~2/3 of WQHD) the ceilings are widened back to the pre-#7 pair so the
+     strip distributes evenly and tabs read uniformly again — see the
+     min-width: 1710px override below the :root block. */
   --uc-active-tab-width: clamp(100px, 30vw, 190px);
   --uc-inactive-tab-width: clamp(100px, 20vw, 120px);
   /* Tab min width (opt-in): 76px = Firefox default (browser.tabs.tabMinWidth).
@@ -135,6 +140,52 @@
   --uc-active-tab-background: transparent;
   --uc-active-tab-underline: 0;
 
+}
+
+/* Wide-window tab widths (>= 1710px physical, ~2/3 of WQHD). Restores the
+   pre-#7 ceilings: inactive caps near the active one, so flex distributes strip
+   space evenly and tabs look uniform — the everyday-comfortable behaviour.
+   Below that the narrow defaults above keep the active tab visibly larger.
+
+   The catch: `width` is CSS pixels, which DPI scaling shrinks (1920 physical
+   at 125% = 1536 CSS px), so a plain `min-width: 1710px` never fires on a
+   scaled display. CSS can't read the scale factor as a number, but it can
+   match it via `resolution` (dppx == OS scale). So the threshold is tiered per
+   scale, each set to 1710 / scale CSS px, all writing the SAME wide values —
+   overlap between tiers is harmless. The highest dppx tier <= the current
+   scale wins, giving a constant ~1710 *physical*-px trigger at any scaling.
+     100%  -> 1710 / 1.00 = 1710     150%  -> 1710 / 1.50 = 1140
+     125%  -> 1710 / 1.25 = 1368     175%  -> 1710 / 1.75 =  977
+                                     200%  -> 1710 / 2.00 =  855 */
+@media (min-width: 1710px) {
+  :root {
+    --uc-active-tab-width: clamp(100px, 30vw, 250px);
+    --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  }
+}
+@media (min-resolution: 1.2dppx) and (min-width: 1368px) {
+  :root {
+    --uc-active-tab-width: clamp(100px, 30vw, 250px);
+    --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  }
+}
+@media (min-resolution: 1.45dppx) and (min-width: 1140px) {
+  :root {
+    --uc-active-tab-width: clamp(100px, 30vw, 250px);
+    --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  }
+}
+@media (min-resolution: 1.7dppx) and (min-width: 977px) {
+  :root {
+    --uc-active-tab-width: clamp(100px, 30vw, 250px);
+    --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  }
+}
+@media (min-resolution: 1.95dppx) and (min-width: 855px) {
+  :root {
+    --uc-active-tab-width: clamp(100px, 30vw, 250px);
+    --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  }
 }
 
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -402,6 +402,11 @@ sidebar-main,
 
 #navigator-toolbox {
   border-bottom: 0 solid transparent !important;
+  /* Nova frames the toolbox with a 4px margin, letting the window
+     background show through as a border. FoxOne is edge-to-edge, so drop
+     it. Side effect: removing the 4px top margin realigns #PanelUI-button
+     (position: fixed; top: 0), which the margin had pushed out of sync. */
+  margin: 0 !important;
 }
 
 #browser,

--- a/userChrome.css
+++ b/userChrome.css
@@ -1298,6 +1298,16 @@ tab-split-view-wrapper {
     --tab-max-width: 300px!important;
 }
 
+#tabbrowser-tabpanels {
+  &[splitview] {
+    & .browserContainer {
+      .deck-selected > & {
+        outline: 2px solid #fabd2f !important;
+      }
+    }
+  }
+}
+
 .split-view-splitter {
   border: none !important;
   /* same adaptive splitter colour as #sidebar-splitter — blends in light

--- a/userChrome.css
+++ b/userChrome.css
@@ -66,7 +66,10 @@
   --container-tabs-indicator-margin: 10px;
   --uc-identity-glow: 0 1px 10px 1px;
 
-  /* Windows control button width — used for Hamburger positioning */
+  /* Windows control button width. Fallback only: on non-macOS the hamburger
+     auto-tracks the real window-control box via CSS anchor positioning, so
+     this value is used just on macOS and on Firefox builds without anchor
+     support. No need to measure it by hand on a modern build. */
   --uc-window-buttons-width: 138px;
 
   /* Hamburger button width — reserved in tab bar to prevent overlap */
@@ -957,7 +960,9 @@ browser[type="content"],
 
 
 /* ==========================================================================
-   HAMBURGER MENU — fixed position next to Windows control buttons.
+   HAMBURGER MENU — fixed position next to the window control buttons.
+   Base rule uses the --uc-window-buttons-width fallback; non-macOS overrides
+   it below with CSS anchor positioning so it tracks the real box width.
    ========================================================================== */
 
 #PanelUI-button {
@@ -968,6 +973,22 @@ browser[type="content"],
   z-index: 1000 !important;
   display: flex !important;
   align-items: center !important;
+}
+
+/* Non-macOS (Windows, Linux): anchor the hamburger's right edge to the left
+   edge of the real window-control box, so it auto-adapts to display scaling,
+   custom titlebar themes and per-DE control widths with no hand-set value.
+   The anchor() fallback keeps the old --uc-window-buttons-width behaviour on
+   Firefox builds without anchor positioning, so there is no regression.
+   Excluded on macOS, where the control box sits on the LEFT (traffic lights)
+   and would fling the hamburger to the wrong edge. (Issue #9) */
+@media not (-moz-platform: macos) {
+  .titlebar-buttonbox-container {
+    anchor-name: --uc-winbtns !important;
+  }
+  #PanelUI-button {
+    right: anchor(--uc-winbtns left, var(--uc-window-buttons-width)) !important;
+  }
 }
 
 /* ==========================================================================

--- a/userChrome.css
+++ b/userChrome.css
@@ -39,9 +39,12 @@
   /* Vertical URL Bar spacing adjustment */
   --uc-urlbar-top-spacing: 1px;
 
-  /* Dynamic tab widths */
+  /* Dynamic tab widths. The inactive ceiling is intentionally lower than the
+     active one: inactive tabs cap sooner, freeing strip space for the active
+     tab to grow visibly larger. Raise it back toward the active ceiling and the
+     active-tab size advantage only appears at very wide strips (issue #7). */
   --uc-active-tab-width: clamp(100px, 30vw, 250px);
-  --uc-inactive-tab-width: clamp(100px, 20vw, 200px);
+  --uc-inactive-tab-width: clamp(100px, 20vw, 120px);
   /* Tab min width (opt-in): 76px = Firefox default (browser.tabs.tabMinWidth).
      Lower it (e.g. 36px) to allow narrower tabs / fit more before overflow scroll */
   --uc-tab-min-width: 76px;

--- a/userChrome.css
+++ b/userChrome.css
@@ -534,6 +534,28 @@ sidebar-main,
   margin: auto;
 }
 
+/* Nova's search-mode switcher (the engine icon) is a moz-button; its
+   visible button lives in the shadow DOM (part="button") and draws a violet
+   frame (#d4c1ff in dark mode) from the design tokens. Rather than fight to
+   remove it, recolour it to FoxOne's accent so it reads as an on-brand
+   search-mode indicator. Cover the host tokens (incl. the full
+   --focus-outline shorthand, missed earlier) and the exposed part, since
+   the exact channel resisted isolation. */
+.searchmode-switcher {
+  --focus-outline: 2px solid var(--uc-color-accent) !important;
+  --focus-outline-color: var(--uc-color-accent) !important;
+  --button-border: 1px solid var(--uc-color-accent) !important;
+  --button-border-color: var(--uc-color-accent) !important;
+  --button-border-color-active: var(--uc-color-accent) !important;
+  --button-border-color-hover: var(--uc-color-accent) !important;
+  --button-border-color-selected: var(--uc-color-accent) !important;
+  --border-color-selected: var(--uc-color-accent) !important;
+}
+.searchmode-switcher::part(button) {
+  border-color: var(--uc-color-accent) !important;
+  outline-color: var(--uc-color-accent) !important;
+}
+
 .urlbar-page-action {
   padding: 0 inherit !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -43,7 +43,7 @@
      active one: inactive tabs cap sooner, freeing strip space for the active
      tab to grow visibly larger. Raise it back toward the active ceiling and the
      active-tab size advantage only appears at very wide strips (issue #7). */
-  --uc-active-tab-width: clamp(100px, 30vw, 250px);
+  --uc-active-tab-width: clamp(100px, 30vw, 190px);
   --uc-inactive-tab-width: clamp(100px, 20vw, 120px);
   /* Tab min width (opt-in): 76px = Firefox default (browser.tabs.tabMinWidth).
      Lower it (e.g. 36px) to allow narrower tabs / fit more before overflow scroll */

--- a/userChrome.css
+++ b/userChrome.css
@@ -226,8 +226,13 @@ sidebar-main,
   display: none !important;
 }
 
-/* fix Shield Icon padding */
+/* fix Shield Icon padding — Nova moved urlbar-input-container from id to
+   class, so match both. */
 #urlbar-input-container[pageproxystate="valid"]
+  > #tracking-protection-icon-container
+  > #tracking-protection-icon-box
+  > #tracking-protection-icon,
+.urlbar-input-container[pageproxystate="valid"]
   > #tracking-protection-icon-container
   > #tracking-protection-icon-box
   > #tracking-protection-icon {
@@ -424,16 +429,26 @@ sidebar-main,
   border-radius: calc(var(--uc-urlbar-rounded) * var(--uc-border-radius)) !important;
 }
 
-#urlbar-background {
-  border: transparent !important;
+/* Nova rebuilt the urlbar as <moz-urlbar> and moved its internals from
+   id to class (.urlbar-background, .urlbar-input-container). The new
+   .urlbar-input-container carries a 1px deemphasized border
+   (urlbar-searchbar.css). Reset both the legacy id and the Nova classes
+   so the field keeps blending into the toolbar across channels. */
+#urlbar-background,
+.urlbar-background,
+.urlbar-input-container {
+  border: none !important;
 }
 
 #urlbar[focused="true"] > #urlbar-background,
-#urlbar:not([open]) > #urlbar-background {
+#urlbar[focused="true"] > .urlbar-background,
+#urlbar:not([open]) > #urlbar-background,
+#urlbar:not([open]) > .urlbar-background {
   background: var(--uc-highlight-colour) !important;
 }
 
-#urlbar[open] > #urlbar-background {
+#urlbar[open] > #urlbar-background,
+#urlbar[open] > .urlbar-background {
   background: var(--toolbar-field-background-color) !important;
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -896,7 +896,7 @@ browser[type="content"],
               margin-inline 0.2s ease, padding-inline 0.2s ease !important;
 }
 
-#nav-bar:hover #identity-permission-box,
+#urlbar:hover #identity-permission-box,
 #urlbar[focused="true"] #identity-permission-box {
   max-width: none !important;
   opacity: 1 !important;
@@ -933,14 +933,14 @@ browser[type="content"],
               padding 0.2s ease, margin 0.2s ease !important;
 }
 
-#nav-bar:hover #userContext-indicator,
+#urlbar:hover #userContext-indicator,
 #urlbar[focused="true"] #userContext-indicator {
   max-width: 200px !important;
   opacity: 1 !important;
   margin-inline: 2px !important;
 }
 
-#nav-bar:hover #userContext-label,
+#urlbar:hover #userContext-label,
 #urlbar[focused="true"] #userContext-label {
   max-width: 200px !important;
   opacity: 1 !important;
@@ -963,11 +963,11 @@ browser[type="content"],
               padding 0.2s ease, margin 0.2s ease !important;
 }
 
-#nav-bar:hover #reader-mode-button,
-#nav-bar:hover #taskbar-tabs-button,
-#nav-bar:hover #translations-button,
-#nav-bar:hover #pageAction-urlbar-_testpilot-containers,
-#nav-bar:hover #pageAction-urlbar-_e26226b8-5263-4b42-9789-504fde4443b3_,
+#urlbar:hover #reader-mode-button,
+#urlbar:hover #taskbar-tabs-button,
+#urlbar:hover #translations-button,
+#urlbar:hover #pageAction-urlbar-_testpilot-containers,
+#urlbar:hover #pageAction-urlbar-_e26226b8-5263-4b42-9789-504fde4443b3_,
 #urlbar[focused="true"] #reader-mode-button,
 #urlbar[focused="true"] #taskbar-tabs-button,
 #urlbar[focused="true"] #translations-button,

--- a/userChrome.css
+++ b/userChrome.css
@@ -284,80 +284,81 @@ sidebar-main,
 
 
 /* ==========================================================================
-   RESPONSIVE — One-line layout at >= 1000px
+   ONE-LINE LAYOUT – urlbar shares the toolbar row with the tabs.
+   Always on, at every window width. When urlbar + tabs no longer fit
+   comfortably, tabs shrink to their min-width and the strip scrolls
+   (native arrowscrollbox). Deliberately no width breakpoint: switching the
+   toolbox flex layout on resize leaves the urlbar's paint layer stale until
+   a repaint (Ctrl+L / tab switch), so the structure stays constant.
    ========================================================================== */
 
-@media (min-width: 1000px) {
-  #navigator-toolbox {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-  }
+#navigator-toolbox {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+}
 
-  /* Prevent notifications toolbar from becoming a 1px flex column —
-     force it to its own row so it collapses when empty. */
-  #notifications-toolbar {
-    width: 100% !important;
-    order: 99 !important;
-  }
+/* Prevent notifications toolbar from becoming a 1px flex column —
+   force it to its own row so it collapses when empty. */
+#notifications-toolbar {
+  width: 100% !important;
+  order: 99 !important;
+}
 
-  #nav-bar {
-    order: var(--uc-urlbar-position);
-    width: var(--uc-urlbar-min-width);
-    /* !important required: Firefox overrides our transition with
-       :root[sessionrestored][lwtheme] #nav-bar { transition-property:
-       background-color } when any lwtheme (Alpenglow, custom) is active. */
-    transition: width 0.25s ease !important;
-    &.browser-titlebar {
-      width: 100%;
-    }
-  }
-
-  #nav-bar #urlbar-container {
-    min-width: 0px !important;
-    width: auto !important;
-  }
-
-  #titlebar {
-    width: calc(100vw - var(--uc-urlbar-min-width) - 1px);
-    transition: width 0.25s ease !important;
-  }
-
-  #TabsToolbar {
+#nav-bar {
+  order: var(--uc-urlbar-position);
+  width: var(--uc-urlbar-min-width);
+  /* !important required: Firefox overrides our transition with
+     :root[sessionrestored][lwtheme] #nav-bar { transition-property:
+     background-color } when any lwtheme (Alpenglow, custom) is active. */
+  transition: width 0.25s ease !important;
+  &.browser-titlebar {
     width: 100%;
   }
+}
 
-  #tabbrowser-tabs:not([orient="vertical"]) {
-    max-width: calc(100% - var(--uc-hamburger-width) - var(--uc-toolbar-button-width) - var(--uc-drag-space) - var(--uc-newtab-width)) !important;
-	}
+#nav-bar #urlbar-container {
+  min-width: 0px !important;
+  width: auto !important;
+}
 
-  #navigator-toolbox:focus-within #nav-bar {
-    width: var(--uc-urlbar-max-width);
-    &.browser-titlebar {
-      width: 100%;
-    }
+#titlebar {
+  width: calc(100vw - var(--uc-urlbar-min-width) - 1px);
+  transition: width 0.25s ease !important;
+}
+
+#TabsToolbar {
+  width: 100%;
+}
+
+#tabbrowser-tabs:not([orient="vertical"]) {
+  max-width: calc(100% - var(--uc-hamburger-width) - var(--uc-toolbar-button-width) - var(--uc-drag-space) - var(--uc-newtab-width)) !important;
+}
+
+#navigator-toolbox:focus-within #nav-bar {
+  width: var(--uc-urlbar-max-width);
+  &.browser-titlebar {
+    width: 100%;
   }
-  #navigator-toolbox:focus-within #titlebar {
-    width: calc(100vw - var(--uc-urlbar-max-width) - 1px);
-  }
+}
+#navigator-toolbox:focus-within #titlebar {
+  width: calc(100vw - var(--uc-urlbar-max-width) - 1px);
 }
 
 /* Vertical tabs — toolbar layout override.
    Tabs live in the sidebar, so the toolbar only holds URL bar + buttons.
    Uses :has() to detect vertical mode reliably in userChrome.css. */
-@media (min-width: 1000px) {
-  :root:has(#tabbrowser-tabs[orient="vertical"]) #nav-bar {
-    flex: 1 !important;
-    width: auto !important;
-  }
+:root:has(#tabbrowser-tabs[orient="vertical"]) #nav-bar {
+  flex: 1 !important;
+  width: auto !important;
+}
 
-  :root:has(#tabbrowser-tabs[orient="vertical"]) #titlebar {
-    width: auto !important;
-  }
+:root:has(#tabbrowser-tabs[orient="vertical"]) #titlebar {
+  width: auto !important;
+}
 
-  :root:has(#tabbrowser-tabs[orient="vertical"]) #PanelUI-button {
-    position: static !important;
-  }
+:root:has(#tabbrowser-tabs[orient="vertical"]) #PanelUI-button {
+  position: static !important;
 }
 
 
@@ -380,26 +381,24 @@ sidebar-main,
   /* Position traffic lights at the left edge of the toolbar, vertically
      centred.  absolute (not fixed) so the buttons track the toolbox,
      not the viewport — gives the correct macOS inset. */
-  @media (min-width: 1000px) {
-    #navigator-toolbox {
-      position: relative !important;
-    }
+  #navigator-toolbox {
+    position: relative !important;
+  }
 
-    .titlebar-buttonbox-container {
-      position: absolute !important;
-      left: 0 !important;
-      top: 12px !important;
-      z-index: 1000 !important;
-      display: block !important;
-    }
+  .titlebar-buttonbox-container {
+    position: absolute !important;
+    left: 0 !important;
+    top: 12px !important;
+    z-index: 1000 !important;
+    display: block !important;
+  }
 
-    /* Reserve left-side space — box-sizing ensures padding stays within
-       the nav-bar's flex width instead of overflowing the layout.
-       Drops in fullscreen where macOS hides the traffic lights. */
-    :root:not([inFullscreen]) #nav-bar {
-      box-sizing: border-box !important;
-      padding-inline-start: var(--uc-traffic-light-width) !important;
-    }
+  /* Reserve left-side space — box-sizing ensures padding stays within
+     the nav-bar's flex width instead of overflowing the layout.
+     Drops in fullscreen where macOS hides the traffic lights. */
+  :root:not([inFullscreen]) #nav-bar {
+    box-sizing: border-box !important;
+    padding-inline-start: var(--uc-traffic-light-width) !important;
   }
 }
 
@@ -929,21 +928,16 @@ browser[type="content"],
 
 /* ==========================================================================
    HAMBURGER MENU — fixed position next to Windows control buttons.
-   Only applies in one-line layout (>= 1000px). Below that, the buttons
-   fall back to their natural position in the nav-bar so they don't
-   overlap the tab strip in the two-row layout.
    ========================================================================== */
 
-@media (min-width: 1000px) {
-  #PanelUI-button {
-    position: fixed !important;
-    right: var(--uc-window-buttons-width) !important;
-    top: 0 !important;
-    height: 44px !important;
-    z-index: 1000 !important;
-    display: flex !important;
-    align-items: center !important;
-  }
+#PanelUI-button {
+  position: fixed !important;
+  right: var(--uc-window-buttons-width) !important;
+  top: 0 !important;
+  height: 44px !important;
+  z-index: 1000 !important;
+  display: flex !important;
+  align-items: center !important;
 }
 
 /* ==========================================================================
@@ -954,14 +948,8 @@ browser[type="content"],
    ========================================================================== */
 
 #TabsToolbar-customization-target > toolbaritem {
-  margin-inline-start: var(--uc-drag-space) !important;
-}
-
-@media (min-width: 1000px) {
-  #TabsToolbar-customization-target > toolbaritem {
-    margin-inline-start: auto !important;
-    margin-inline-end: var(--uc-hamburger-width) !important;
-  }
+  margin-inline-start: auto !important;
+  margin-inline-end: var(--uc-hamburger-width) !important;
 }
 
 

--- a/userContent.css
+++ b/userContent.css
@@ -41,3 +41,38 @@
     }
   }
 }
+
+
+/* ==========================================================================
+   SETTINGS PAGES — about:preferences, about:addons (Gruvbox Dark)
+   Pins background and selection/accent so they look identical across
+   machines, regardless of the OS accent colour or the active Firefox theme.
+   Both the legacy --in-content-* names and the newer --color-* design
+   tokens are set, so this survives Firefox's token renaming.
+   ========================================================================== */
+
+@-moz-document url-prefix("about:preferences"), url-prefix("about:addons") {
+  @media (prefers-color-scheme: dark) {
+    :root {
+      /* Page background */
+      --in-content-page-background: #282828 !important;
+      --background-color-canvas: #282828 !important;
+
+      /* Selection / accent — Gruvbox bright yellow, dark text for contrast */
+      --in-content-accent-color: #fabd2f !important;
+      --in-content-accent-color-active: #fabd2f !important;
+      --in-content-item-selected: #fabd2f !important;
+      --in-content-item-selected-text: #282828 !important;
+
+      --color-accent-primary: #fabd2f !important;
+      --color-accent-primary-hover: #fabd2f !important;
+      --color-accent-primary-active: #fabd2f !important;
+    }
+
+    /* Highlighted text */
+    ::selection {
+      background-color: #fabd2f !important;
+      color: #282828 !important;
+    }
+  }
+}


### PR DESCRIPTION
## FoxOne for Firefox Nova

Brings FoxOne to the Nova UI. Tested and stable on Firefox 152+ with `browser.nova.enabled`.

### Highlights
- One-line layout, now unconditional (dropped the 1000px breakpoint)
- Nova chrome reskinned: navbar, bookmarks bar, urlbar dropdown, search-mode switcher, split-view outline, sidebar/split splitters - all theme-adaptive in Gruvbox
- Dynamic toolbar support: up to two extension icons pinned by the hamburger, revealed on hover (replaces the old single static pin)
- New opt-ins: `--uc-hide-urlbar-buttons`, `--uc-hide-extension-icons`
- about:preferences / about:addons pinned to Gruvbox dark
- Scale-aware tab sizing (physical-px thresholds, DPI-correct)
- Docs synced with current CSS variables

### Compatibility
Dual-written (Proton & Nova). Classic Firefox should still work but is no longer tested - use the 2.3 release for a known-good Proton build.
