### PR TITLE
Reveal container label only on focus, keep hover to the colored indicator

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1528,7 +1528,7 @@ sidebar-main {
 
 #identity-box.extensionPage { display: none !important; }
 
-/* Container indicator — hide by default, reveal on hover/focus */
+/* Container indicator: hidden by default; indicator shown on hover/focus, text label on focus only */
 #userContext-label,
 #userContext-indicator {
   max-width: 0 !important;
@@ -1547,7 +1547,6 @@ sidebar-main {
   margin-inline: 2px !important;
 }
 
-#urlbar:hover #userContext-label,
 #urlbar[focused="true"] #userContext-label {
   max-width: 200px !important;
   opacity: 1 !important;


### PR DESCRIPTION
As discussed in #34: this drops the `#urlbar:hover #userContext-label` selector from the reveal rule, so hovering shows just the colored indicator and the text label waits for the focused state. The indicator rule is untouched.

I've been running the same change on my own install (on 2.3, where the selector is `#nav-bar:hover` instead). The dot alone is plenty to tell which container you're in, and the URL is clickable again with long container names.

Fixes #34