### PR TITLE
Update userChrome.css

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -52,6 +52,9 @@
   /* Inactive tab hover title color (issue #16) */
   --uc-tab-hover-text: #ffda85;
 
+  /* Firefoxs Multi Container Tab Indiktator line (0 = bottom, 1 = top)  */
+  --uc-container-line-top: 1;
+
   /* Context menu: "Open Link in Split View" (0 = hidden, 1 = visible) */
   --uc-show-context-splitview: 0;
 
@@ -1862,20 +1865,38 @@ sidebar-main {
   box-shadow: 0 -1px 10px 1px var(--tab-selected-textcolor, #fabd2f) !important;
 }
 
-/* container tabs indicator */
+/* container tabs indicator (position toggle in CONFIG)
+   Nova puts its 4px stripe at the top of the tab and shifts it a further -6px
+   into the edge; the 1px FoxOne line inherits both. Default pins it to the
+   bottom edge on the same geometry as the pinned-tab indicator above; the
+   style query at 1 puts it back on top, un-shifted. */
 #TabsToolbar .tab-context-line {
-  margin: 2px 10px 0
-    10px !important;
   height: 1px !important;
-  /* Nova shifts its 4px stripe up by -6px into the tab edge; the 1px FoxOne
-     line inherits the shift and loses most of its glow to clipping. Pin it
-     back into flow. */
-  inset-block-start: 0 !important;
+  position: absolute !important;
+  inset-block-start: auto !important;
+  inset-block-end: 0 !important;
+  inset-inline: 10px !important;
+  margin: 0 !important;
 }
 .tab-context-line {
-  /* Same lift as the urlbar indicator: boosted core, raw colour for the glow. */
+  /* Same lift as the urlbar indicator: boosted core, raw colour for the glow.
+     Glow points up, away from the bottom tab edge, so it isn't clipped. */
   background-color: oklch(from var(--identity-icon-color) calc(l + 0.12) calc(c * 1.15) h) !important;
-  box-shadow: 0 1px 10px 1px var(--identity-tab-color) !important;
+  box-shadow: 0 -1px 10px 1px var(--identity-tab-color) !important;
+}
+/* Top placement is the 3.4.5 geometry: back into flow, 2px clear of the tab
+   edge so the glow has room on both sides, Nova's -6px shift cancelled by
+   inset-block-start: 0. Pinning it flat to the edge instead costs half the
+   glow and reads as the muted pre-3.4.5 line. */
+@container style(--uc-container-line-top: 1) {
+  #TabsToolbar .tab-context-line {
+    position: relative !important;
+    inset-block-start: 0 !important;
+    inset-block-end: auto !important;
+    inset-inline: auto !important;
+    margin: 2px 10px 0 10px !important;
+    box-shadow: 0 1px 10px 1px var(--identity-tab-color) !important;
+  }
 }
 
 /* show favicon when media is playing but tab is hovered */


### PR DESCRIPTION
Added an option for the tab bar multi account container line to be on top or on the bottom.

Laut deinen Screenshots sprichst du deutsch, daher etwas Hintergrund: Das Upate auf Firefox 153 hat etwas kaputt gemacht, ich weiß nicht genau was, aber die Tab Indikatorbar ist jetzt oben. Bei Version 2 oder 3 war es noch unten. Ich habe in deinem commit Style versucht eine Variable einzubauen für oben/unten. Und natürlich den Fix von gestern 3.4.5 mit eingebaut. 
Das war einfach mega strange: unten war die Linie leuchtend klar, wenn sie per Variable oben war, war sie plötzlich total blurred? 
Whatever, ich hab es gefixt. PR ist raus - freue mich auf dein Feedback! 

PS: Super cooles Konzept, ich verfolge das schon seit ein paar Monten - bleib dran! 