### PR TITLE
Add #ipprotection-button (VPN) to hidden nav buttons

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1533,7 +1533,8 @@ sidebar-main {
   #back-button,
   #forward-button,
   #reload-button,
-  #stop-reload-button {
+  #stop-reload-button,
+  #ipprotection-button {
     display: none !important;
   }
 }
@@ -1544,7 +1545,8 @@ sidebar-main {
   #back-button,
   #forward-button,
   #reload-button,
-  #stop-reload-button {
+  #stop-reload-button,
+  #ipprotection-button {
     opacity: 0 !important;
     max-width: 0 !important;
     min-width: 0 !important;
@@ -1558,7 +1560,8 @@ sidebar-main {
     #back-button,
     #forward-button,
     #reload-button,
-    #stop-reload-button
+    #stop-reload-button,
+    #ipprotection-button
   ) {
     opacity: 1 !important;
     width: revert !important;
@@ -1582,7 +1585,8 @@ sidebar-main {
     #back-button,
     #forward-button,
     #reload-button,
-    #stop-reload-button
+    #stop-reload-button,
+    #ipprotection-button
   ) {
     opacity: 1 !important;
     width: revert !important;
@@ -2623,7 +2627,8 @@ html[id^="taskbartab"] #unified-extensions-button {
 
   /* Auto-hide nav buttons reveal */
   #reload-button,
-  #stop-reload-button { transition: none !important; }
+  #stop-reload-button,
+  #ipprotection-button { transition: none !important; }
 
   /* Urlbar hover-reveal groups */
   #identity-permission-box { transition: none !important; }


### PR DESCRIPTION
Hello 👋

This adds the new firefox VPN buttons to the list of hidden navigation buttons.

It should respects the same settings as back and foward buttons.

Feel free to review (however very small change) or comment, and I'll revise if needed.

_No AI was used in the making of this update._

Edit:
For clarity, the VPN button is placed inside the same parent as back and forward buttons, which is why I opted for this solution.

If you want to test yourself, and don't have the button yet, it can be enabled in `about:config` by setting `browser.ipprotection.enabled` to true. and activating VPN from settings.